### PR TITLE
Typescript code review

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,8 +29,7 @@
     "dev": "tsc -w",
     "lint": "eslint src/",
     "test": "jest src/ --collectCoverage",
-    "test-watch": "jest src/ --watch",
-    "test:watch": "jest src/ --watchAll",
+    "test:watch": "jest src/ --watch",
     "build": "rm -rf lib && tsc",
     "prepublish": "yarn test && yarn build"
   },

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
     "dev": "tsc -w",
     "lint": "eslint src/",
     "test": "jest src/ --collectCoverage",
+    "test-watch": "jest src/ --watch",
     "test:watch": "jest src/ --watchAll",
     "build": "rm -rf lib && tsc",
     "prepublish": "yarn test && yarn build"

--- a/src/data/irregularNouns.ts
+++ b/src/data/irregularNouns.ts
@@ -1,12 +1,12 @@
-export interface nounObject {
-  single?: string;
-  plural?: string;
+export interface NounObject {
+  single: string;
+  plural: string;
 }
 
 /**
  * An array of irregular nouns that follow no specific rules
  */
-const irregularNouns: Array<nounObject> = [
+const irregularNouns: Array<NounObject> = [
   {
     single: 'child',
     plural: 'children',

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -160,7 +160,7 @@ describe('When testing isIregular', () => {
 });
 
 describe('When testing schshxzNoun', () => {
-  it('returns an the correct noun', () => {
+  it('returns the correct noun', () => {
     expect(schshxzNoun('bus')).toEqual('buses');
     expect(schshxzNoun('quiz')).toEqual('quizzes');
     expect(schshxzNoun('box')).toEqual('boxes');

--- a/src/index.ts
+++ b/src/index.ts
@@ -76,7 +76,7 @@ export const isNoun = (noun: string): SuffixReturn => {
   return null;
 };
 
-export const standardNoun = (noun: string): SuffixReturn => `${noun}s`;
+export const standardNoun = (noun: string): string => `${noun}s`;
 
 /**
  *

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,19 +1,21 @@
-import irregularNouns from './data/irregularNouns';
+import irregularNouns, { NounObject } from './data/irregularNouns';
 import nonChangingNouns from './data/nonChangingNouns';
 
-type suffixReturn = string | null;
+type SuffixReturn = string | null;
 
-export const isIregular = (noun: string, count = 1): suffixReturn => {
-  const value = count === 1 ? 'single' : 'plural';
-  const getNoun = irregularNouns.find((item) => item.single === noun) || {};
-  return getNoun[value] || null;
+export const isIregular = (noun: string, count = 1): SuffixReturn => {
+  const kind: keyof NounObject = count === 1 ? 'single' : 'plural';
+  const nounObject = irregularNouns.find((item) => item.single === noun);
+  return nounObject
+    ? nounObject[kind]
+    : null;
 };
 
-export const isNonChanging = (noun: string): suffixReturn => {
+export const isNonChanging = (noun: string): SuffixReturn => {
   return nonChangingNouns.find((item) => item === noun) || null;
 };
 
-export const endsInO = (noun: string): suffixReturn => {
+export const endsInO = (noun: string): SuffixReturn => {
   if (/[^aeiou]o$/gim.test(noun)) {
     return `${noun}es`;
   }
@@ -23,7 +25,7 @@ export const endsInO = (noun: string): suffixReturn => {
   return null;
 };
 
-export const endsInY = (noun: string): suffixReturn => {
+export const endsInY = (noun: string): SuffixReturn => {
   if (/[^aeiou]y$/gim.test(noun)) {
     return noun.replace('y', 'ies');
   }
@@ -33,7 +35,7 @@ export const endsInY = (noun: string): suffixReturn => {
   return null;
 };
 
-export const endsInFOrFe = (noun: string): suffixReturn => {
+export const endsInFOrFe = (noun: string): SuffixReturn => {
   const exceptions = ['roof', 'cliff', 'proof'];
 
   if (exceptions.indexOf(noun) !== -1) {
@@ -46,7 +48,7 @@ export const endsInFOrFe = (noun: string): suffixReturn => {
   return null;
 };
 
-export const schshxzNoun = (noun: string): suffixReturn => {
+export const schshxzNoun = (noun: string): SuffixReturn => {
   if (/z$/gim.test(noun)) {
     return `${noun}zes`;
   }
@@ -58,7 +60,7 @@ export const schshxzNoun = (noun: string): suffixReturn => {
   return null;
 };
 
-export const usNoun = (noun: string): suffixReturn => {
+export const usNoun = (noun: string): SuffixReturn => {
   const regex = /us$/gim;
   if (regex.test(noun)) {
     return noun.replace(regex, 'i');
@@ -66,7 +68,7 @@ export const usNoun = (noun: string): suffixReturn => {
   return null;
 };
 
-export const isNoun = (noun: string): suffixReturn => {
+export const isNoun = (noun: string): SuffixReturn => {
   const regex = /is$/gim;
   if (regex.test(noun)) {
     return noun.replace(regex, 'es');
@@ -74,7 +76,7 @@ export const isNoun = (noun: string): suffixReturn => {
   return null;
 };
 
-export const standardNoun = (noun: string): suffixReturn => `${noun}s`;
+export const standardNoun = (noun: string): SuffixReturn => `${noun}s`;
 
 /**
  *
@@ -82,7 +84,7 @@ export const standardNoun = (noun: string): suffixReturn => `${noun}s`;
  * @param count The count of that noun, `[2]`
  * @returns A formatted string, `[2 heroes]`
  */
-const makeSuffix = (noun: string, count = 1): suffixReturn => {
+const makeSuffix = (noun: string, count = 1): SuffixReturn => {
   const nounFns = [
     isIregular,
     isNonChanging,
@@ -91,11 +93,9 @@ const makeSuffix = (noun: string, count = 1): suffixReturn => {
     endsInFOrFe,
     isNoun,
     schshxzNoun,
-    standardNoun,
   ];
-  let result!: string;
 
-  if (typeof noun !== 'string' || noun === undefined) {
+  if (typeof noun !== 'string') {
     throw new TypeError('expected a string');
   }
 
@@ -103,14 +103,13 @@ const makeSuffix = (noun: string, count = 1): suffixReturn => {
   if (count < 0) return null;
 
   for (let i = 0; i < nounFns.length; i += 1) {
-    const callFn = nounFns[i](noun, count);
-    if (callFn !== null) {
-      result = `${count} ${callFn}`;
-      break;
+    const nounFnResult = nounFns[i](noun, count);
+    if (nounFnResult !== null) {
+      return `${count} ${nounFnResult}`;
     }
   }
 
-  return result;
+  return `${count} ${standardNoun(noun)}`;
 };
 
 export default makeSuffix;

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -12,7 +12,9 @@
     "esModuleInterop": true,
     "skipLibCheck": true,
     "forceConsistentCasingInFileNames": true,
-    "removeComments": false
+    "removeComments": false,
+    "noImplicitReturns": true,
+    "noImplicitThis": true
   },
   "include": ["src"],
   "exclude": ["node_modules", "**/*.test.ts", "lib"]


### PR DESCRIPTION
- added test-watch script so the tests may be run during development (it helps with checking if something got broken in PR).
- renamed all types and interfaces in PascalCase: I think it's universally accepted codestyle.
- made both properties in NounObject required. Although I am not sure if you actually need "single" since you return early on `count === 1`
- fixed typo in tests
- made isIregular a bit more type safe, typescript will throw error if NounObject key would ever change
- typeof noun !== 'string' will already return true if noun === undefined, removed this check
- `let result!: string` is a bit insecure, refactored the code to guarantee standardNoun is returned in the end and returns string
- added a few flags in tsconfig for type safety